### PR TITLE
Redimensionnement des images pour addWeighted()

### DIFF
--- a/ascii18.py
+++ b/ascii18.py
@@ -660,6 +660,7 @@ class Matrix(QMainWindow):
                     ret, frame = capture.read()
                     if ret:
                         f = frame
+                        f = cv2.resize(f, (width, height))
                         combined_frame = cv2.addWeighted(f, .5, canvas_resized, 1, 0)
                         
                         frame = combined_frame


### PR DESCRIPTION
Écran noir à la place la vidéo temps réel -> addWeighted() a besoin que les 2 images soient bien aux mêmes dimensions -> redimensionnement de f avant appel de addWeighted()